### PR TITLE
Add CMSSW script to allow for cmsrel

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Check out the code:
 
 ```
 # set up CMSSW
+source /cvmfs/cms.cern.ch/cmsset_default.sh
 cmsrel CMSSW_13_0_10
 cd CMSSW_13_0_10/src
 cmsenv


### PR DESCRIPTION
I was running through the instructions, and a strict word-for-word entering of the instructions didn't allow for cmsrel on the lpc cluster, but this script should make it available.